### PR TITLE
GoogleCalendarから臨時休診日を取得する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,9 @@ gem 'draper'
 # gem 'administrate'
 # gem 'administrate-field-enum'
 
+# 祝日用
+gem 'holiday_jp'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,7 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
+    holiday_jp (0.8.1)
     hpricot (0.8.6)
     html2slim (0.2.0)
       hpricot
@@ -404,6 +405,7 @@ DEPENDENCIES
   google-api-client
   google-apis-calendar_v3
   googleauth
+  holiday_jp
   html2slim
   importmap-rails
   jbuilder

--- a/app/controllers/first_interviews_controller.rb
+++ b/app/controllers/first_interviews_controller.rb
@@ -9,7 +9,7 @@ class FirstInterviewsController < ApplicationController
     @first_reservation = @first_interview.reservation_interviews.build(reservation_id: params[:reservation_id])
     reservation = Reservation.find(params[:reservation_id])
     reservation_start_time = reservation.start_time
-    reservation_end_time = reservation_start_time + 60 * 60
+    reservation_end_time = reservation_start_time + 1.hours
     calendar = Calendar.new
     if @first_reservation.save
       redirect_to reservations_path, success: t('.success')

--- a/app/controllers/repeate_interviews_controller.rb
+++ b/app/controllers/repeate_interviews_controller.rb
@@ -9,7 +9,7 @@ class RepeateInterviewsController < ApplicationController
     @repeate_reservation = @repeate_interview.reservation_interviews.build(reservation_id: params[:reservation_id])
     reservation = Reservation.find(params[:reservation_id])
     reservation_start_time = reservation.start_time
-    reservation_end_time = reservation_start_time + 60 * 60
+    reservation_end_time = reservation_start_time + 1.hours
     calendar = Calendar.new
     if @repeate_reservation.save
       redirect_to reservations_path, success: t('.success')

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -9,6 +9,8 @@ class ReservationsController < ApplicationController
     @day = params[:day]
     @time = params[:time]
     @start_time = DateTime.parse(@day + " " + @time + " " + "JST")
+    message = Reservation.check_reservation_day(@day.to_date)
+    redirect_to root_path, error: message if !!message
   end
 
   def create

--- a/app/models/business_calendar.rb
+++ b/app/models/business_calendar.rb
@@ -1,0 +1,17 @@
+class BusinessCalendar
+  include ActiveModel::Model
+
+  def self.temporary_closed_day?(day)
+    calendar = Calendar.new
+    closed_days = calendar.closed_days
+    closed_day = closed_days.map { |closed_day| closed_day == day }
+    closed_day.any?
+  end
+
+  def self.temporary_closed_day_pm?(day)
+    calendar = Calendar.new
+    closed_days_pm = calendar.closed_days_pm
+    closed_day_pm = closed_days_pm.map { |closed_day_pm| closed_day_pm == day }
+    closed_day_pm.any?
+  end
+end

--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -26,11 +26,13 @@ class Calendar
   end
 
   def read
+    now = Date.current
+    next_month = now.next_month
     events = @service.list_events(@calendar_id,
                                   single_events: true,
                                   order_by:      "startTime",
-                                  time_min: (Time.new(2022, 9, 1)).iso8601,
-                                  time_max: (Time.new(2022, 9, 20)).iso8601,
+                                  time_min: (Time.new(now.year, now.month, now.day)).iso8601,
+                                  time_max: (Time.new(next_month.year, next_month.month, next_month.day)).iso8601,
                                   )
   end
 
@@ -57,27 +59,15 @@ class Calendar
     )
   end
 
-  # def fetch_events(set_time)
-  #     calendar_id = ENV["CALENDAR_ID"]
-  #     now = Time.current
-  #     start_time = set_time
-  #     end_time = set_time + 1
-  #     response = @service.list_events(calendar_id,
-  #                                 single_events: true,
-  #                                 order_by:      "startTime",
-  #                                 time_min:      Time.new(now.year,now.month,now.day,start_time,0,0).iso8601,
-  #                                 time_max:      Time.new(now.year,now.month,now.day,end_time,0,0).iso8601 )
-  # end
-  #
-  # def reservations_available_time_09_10
-  #   response = self.fetch_events(9)
-  #   if response.items.empty?
-  #     result = '◎'
-  #   elsif response.items.count == 4
-  #     result = '△'
-  #   else
-  #     result = '○'
-  #   end
-  #   result
-  # end
+  def closed_days
+    items = self.read.items
+    rest = items.map { |item| item.start.date if item.summary == '休診日(臨時)' }
+    rest.compact
+  end
+
+  def closed_days_pm
+    items = self.read.items
+    rest = items.map { |item| item.start.date if item.summary == '午後休診(臨時)' }
+    rest.compact
+  end
 end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -12,9 +12,7 @@ class Reservation < ApplicationRecord
   def self.check_reservation_day(day)
     if day < Date.current
       return '過去の日付は選択できません'
-    # elsif
-    #   return '祝日のため選択できません'
-    elsif BusinessCalendar.temporary_closed_day?(day) || BusinessCalendar.temporary_closed_day_pm?(day)
+    elsif BusinessCalendar.temporary_closed_day?(day) #|| BusinessCalendar.temporary_closed_day_pm?(day)
       return '臨時休診のため選択できません'
     end
   end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -9,17 +9,18 @@ class Reservation < ApplicationRecord
   validates :reservation_time, presence: true
   validates :start_time, presence: true
 
-  now = Time.current
-
-  scope :reservations_09_10, -> { where(start_time: Time.new(now.year,now.month,now.day,9,0,0)..Time.new(now.year,now.month,now.day,10,0,0)) }
-  # scope :reservations_10_11, -> { where(reservation_datetime: Time.new(now.year,now.month,now.day,10,0,0)..Time.new(now.year,now.month,now.day,11,0,0)) }
-  # scope :reservations_11_12, -> { where(reservation_datetime: Time.new(now.year,now.month,now.day,11,0,0)..Time.new(now.year,now.month,now.day,12,0,0)) }
-  # scope :reservations_16_17, -> { where(reservation_datetime: Time.new(now.year,now.month,now.day,16,0,0)..Time.new(now.year,now.month,now.day,17,0,0)) }
-  # scope :reservations_17_18, -> { where(reservation_datetime: Time.new(now.year,now.month,now.day,17,0,0)..Time.new(now.year,now.month,now.day,18,0,0)) }
-  # scope :reservations_18_19, -> { where(reservation_datetime: Time.new(now.year,now.month,now.day,18,0,0)..Time.new(now.year,now.month,now.day,19,0,0)) }
+  def self.check_reservation_day(day)
+    if day < Date.current
+      return '過去の日付は選択できません'
+    # elsif
+    #   return '祝日のため選択できません'
+    elsif BusinessCalendar.temporary_closed_day?(day) || BusinessCalendar.temporary_closed_day_pm?(day)
+      return '臨時休診のため選択できません'
+    end
+  end
 
   def delete!
-    self.deleted_at = Time.now
+    self.deleted_at = Time.current
     save!
   end
 

--- a/app/views/simple_calendar/_week_calendar.html.slim
+++ b/app/views/simple_calendar/_week_calendar.html.slim
@@ -13,7 +13,7 @@
         /= calendar.end_week
     = link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view, class: 'btn btn-default btn-sm rounded-full'
     /- reservations = Reservation.reservations_after_three_month
-  table.table.table-striped
+  table.table
     thead
       tr
         th = t('simple_calendar.time')
@@ -22,7 +22,7 @@
     tbody
       - date_range.each_slice(7) do |week|
         tr
-          td = '○月'
+          td = week.first.month.to_s + "月"
           - week.each do |day|
             = content_tag :td, class: calendar.td_classes_for(day) do
               - if defined?(Haml) && respond_to?(:block_is_haml?) && block_is_haml?(passed_block)
@@ -34,20 +34,18 @@
             td = time
             - week.each do |day|
               td.bg-lime-100
-                - if logged_in?
-                  = link_to new_reservation_path(day: day, time: time) do
-                    = '○' unless day.wday == 0
+                - if day.wday == 0
+                  = '休'
                 - else
-                  = link_to login_path do
+                  = link_to new_reservation_path(day: day, time: time) do
                     = '○'
         - pm_times.each do |time|
           tr
             td = time
             - week.each do |day|
               td.bg-lime-100
-                - if logged_in?
-                  = link_to new_reservation_path(day: day, time: time) do
-                    = '○' unless day.wday == 0 || day.wday == 6
+                - if day.wday == 0 || day.wday == 6
+                  = '休'
                 - else
-                  = link_to login_path do
+                  = link_to new_reservation_path(day: day, time: time) do
                     = '○'

--- a/app/views/simple_calendar/_week_calendar.html.slim
+++ b/app/views/simple_calendar/_week_calendar.html.slim
@@ -1,18 +1,9 @@
 .simple-calendar
   .calendar-heading.text-2xl.flex.justify-between
     = link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view, class: 'btn btn-default btn-sm rounded-full'
-    - if calendar.number_of_weeks == 1
-      span.calendar-title.font-bold
-        = t('simple_calendar.week', default: 'Week')
-        /= calendar.week_number
-    - else
-      span.calendar-title.font-bold
-        = t('simple_calendar.week', default: 'Week')
-        /= calendar.week_number
-        /|  -
-        /= calendar.end_week
+    span.calendar-title.font-bold
+      = t('simple_calendar.week', default: 'Week')
     = link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view, class: 'btn btn-default btn-sm rounded-full'
-    /- reservations = Reservation.reservations_after_three_month
   table.table
     thead
       tr

--- a/app/views/simple_calendar/_week_calendar.html.slim
+++ b/app/views/simple_calendar/_week_calendar.html.slim
@@ -34,7 +34,7 @@
             td = time
             - week.each do |day|
               td.bg-lime-100
-                - if day.wday == 0
+                - if day.wday == 0 || HolidayJp.holiday?(day)
                   = '休'
                 - else
                   = link_to new_reservation_path(day: day, time: time) do
@@ -44,7 +44,7 @@
             td = time
             - week.each do |day|
               td.bg-lime-100
-                - if day.wday == 0 || day.wday == 6
+                - if day.wday == 0 || day.wday == 6 || HolidayJp.holiday?(day)
                   = '休'
                 - else
                   = link_to new_reservation_path(day: day, time: time) do

--- a/app/views/static_pages/top.html.slim
+++ b/app/views/static_pages/top.html.slim
@@ -7,5 +7,15 @@
     - else
       = t('.before_login_description')
   .artboard.phone-5.mx-auto
-    = week_calendar events: @reservations do |date, reservations|
-      = date.day
+    - if logged_in?
+      = week_calendar events: @reservations do |date, reservations|
+        = date.day
+      .container.my-10
+        .text-2xl.font-bold
+          = t('defaults.clinic_calendar')
+          iframe[src="https://calendar.google.com/calendar/embed?height=600&wkst=2&bgcolor=%23ffffff&ctz=Asia%2FTokyo&showTitle=0&showNav=1&showPrint=0&showTabs=0&showCalendars=0&showTz=0&mode=MONTH&showDate=0&src=M2x1cXBxbG1sMzVxM2tpMmtiN3RrNGhxYmtAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&color=%237CB342" style="border-width:0" width="400" height="600" frameborder="0" scrolling="no"]
+    - else
+      .container.my-10
+        .text-2xl.font-bold
+          = t('defaults.clinic_calendar')
+          iframe[src="https://calendar.google.com/calendar/embed?height=600&wkst=2&bgcolor=%23ffffff&ctz=Asia%2FTokyo&showTitle=0&showNav=1&showPrint=0&showTabs=0&showCalendars=0&showTz=0&mode=MONTH&showDate=0&src=M2x1cXBxbG1sMzVxM2tpMmtiN3RrNGhxYmtAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&color=%237CB342" style="border-width:0" width="400" height="600" frameborder="0" scrolling="no"]

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -14,6 +14,7 @@ ja:
     tel_reservation: 電話予約(準備中)
     web_reservation: 新規予約
     description_title: その他何かあれば
+    clinic_calendar: 診療日カレンダー
   users:
     new:
       title: 会員登録画面


### PR DESCRIPTION
## 概要

- GoogleCalendarから臨時休診日を取得
- 取得した臨時休診日は予約が取れないように設定
- 祝日の休みも予約カレンダーに反映
- トップページにGoogleCalendarを埋め込み

## issue

- #56 
- #54
